### PR TITLE
v2.3.1: Fix key_mapping import

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,11 +13,18 @@ gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw
 from loguru import logger as log
 
-from key_mapping import (
-    DEFAULT_DIRECTION_KEY_LAYOUT,
-    get_direction_key as resolve_direction_key,
-    normalize_direction_key_layout,
-)
+try:
+    from .key_mapping import (
+        DEFAULT_DIRECTION_KEY_LAYOUT,
+        get_direction_key as resolve_direction_key,
+        normalize_direction_key_layout,
+    )
+except ImportError:
+    from key_mapping import (
+        DEFAULT_DIRECTION_KEY_LAYOUT,
+        get_direction_key as resolve_direction_key,
+        normalize_direction_key_layout,
+    )
 
 
 log.debug("Init HELLDIVERS 2")
@@ -496,7 +503,7 @@ class HellDiversPlugin(PluginBase):
         self.register(
             plugin_name=self.lm.get("plugin.name"),
             github_repo="https://github.com/jslay88/streamcontroller_helldivers_2",
-            plugin_version="2.3.0",
+            plugin_version="2.3.1",
             app_version="1.5.0-beta"
         )
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.0",
+  "version": "2.3.1",
   "thumbnail": "store/thumbnail.png",
   "id": "net_jslay_helldivers_2",
   "name": "HELLDIVERS 2",


### PR DESCRIPTION
## Summary
- Fix plugin failing to load in StreamController since v2.3.0 (`No module named 'key_mapping'`)
- Use relative import for `key_mapping` when loaded as `plugins.net_jslay_helldivers_2.main`
- Bump version to 2.3.1

## Test plan
- [x] `python -m unittest test_key_mapping.py` passes
- [x] Verified `importlib.import_module('plugins.net_jslay_helldivers_2.main')` gets past `key_mapping` import when `data/` is on `sys.path`
- [ ] Restart StreamController and confirm HellDivers page actions load