### PR TITLE
Use relative key_mapping import only

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,18 +13,11 @@ gi.require_version("Adw", "1")
 from gi.repository import Gtk, Adw
 from loguru import logger as log
 
-try:
-    from .key_mapping import (
-        DEFAULT_DIRECTION_KEY_LAYOUT,
-        get_direction_key as resolve_direction_key,
-        normalize_direction_key_layout,
-    )
-except ImportError:
-    from key_mapping import (
-        DEFAULT_DIRECTION_KEY_LAYOUT,
-        get_direction_key as resolve_direction_key,
-        normalize_direction_key_layout,
-    )
+from .key_mapping import (
+    DEFAULT_DIRECTION_KEY_LAYOUT,
+    get_direction_key as resolve_direction_key,
+    normalize_direction_key_layout,
+)
 
 
 log.debug("Init HELLDIVERS 2")


### PR DESCRIPTION
## Summary
- Drop the unnecessary `ImportError` fallback for `key_mapping`
- StreamController always loads plugins as `plugins.{id}.main`

## Test plan
- [x] `python -m unittest test_key_mapping.py` passes
- [x] Verified relative import works when loaded as `plugins.net_jslay_helldivers_2.main`