### PR TITLE
Add add-stratagems skill

### DIFF
--- a/.cursor/skills/add-stratagems/SKILL.md
+++ b/.cursor/skills/add-stratagems/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: add-stratagems
+description: >-
+  Discover, map, generate, and ship new HELLDIVERS 2 stratagems for the
+  StreamController plugin, including plugin PRs, local Flatpak testing, and
+  StreamController-Store hash bumps. Use when the user invokes add-stratagems,
+  asks to add new stratagems, run discover, ship a plugin version, open a store
+  PR, or restore the local StreamController install.
+disable-model-invocation: true
+---
+
+# Add Helldivers 2 Stratagems
+
+End-to-end workflow for new in-game stratagems. Read [AGENTS.md](../../../AGENTS.md) for label rules. Read [local.md](local.md) before any local StreamController or store-fork step. Use `jslay-writing-style` for commits and PR bodies.
+
+Do **not** commit or push unless the user asks.
+
+## Phase selection
+
+| User says | Run |
+|-----------|-----|
+| invoke skill / add new stratagems / discover | Phases 1-5, then stop |
+| commit / PR / ship | Phase 6 |
+| test locally / link into StreamController | Phase 7 |
+| store PR | Phase 8 (plugin must already be on `origin/main`) |
+| restore store plugin / re-enable auto-update | Phase 9 |
+
+## Phase 1: Fresh main
+
+Plugin repo: `/home/jslay/dev/streamcontroller_helldivers_2`
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git checkout -b feat/vX.Y.Z-new-stratagems
+```
+
+`X.Y.Z` is current `manifest.json` version with the minor bumped (2.3.1 → 2.4.0). Patch bumps are for fixes only.
+
+## Phase 2: Discover
+
+```bash
+cd /home/jslay/dev/streamcontroller_helldivers_2
+python3 --version   # asdf python is fine
+[ -d .venv ] || python3 -m venv .venv
+source .venv/bin/activate
+pip install -q -r update/requirements.txt
+python -m update discover -v
+```
+
+`discover` only prints candidates. It does **not** write `config.py`. Suggested `"svg"` values that copy the wiki name are usually wrong.
+
+## Phase 3: Map into `update/config.py`
+
+`STRATAGEM_MAPPINGS` is the only file to edit by hand. Never edit `stratagems.json`, `locales/en_US.json`, or icons except via generate.
+
+### Treat wiki-missing as a rename first
+
+If discover reports `WIKI ENTRIES NOT FOUND` plus a new wiki name that is clearly the same stratagem (same sequence, wiki redirect, "renamed from" on the wiki page):
+
+- Keep the existing **key**
+- Update `wiki` (and `name` if the game renamed it)
+- Keep `svg` unless the SVG repo also renamed the file
+
+### Match wiki to SVG yourself
+
+Wiki uses model numbers (`MG-43 Machine Gun`). SVG repo uses short names (`Machine Gun`). Cross-check unmapped SVG names from discover, then the SVG repo: https://github.com/nvigneux/Helldivers-2-Stratagems-icons-svg
+
+Normalize by stripping prefixes like `A/GM-17`, `B/FLAM-80`, `EXO-51`, `M-103`, `40-K`.
+
+### Missing SVGs
+
+Mission/objective items often have no SVG. Reuse:
+
+- Intel / data / camera → `Upload Data`
+- Drills that share an icon on the wiki → that drill's SVG (`Prospecting Drill`, `Hive Breaker Drill`, …)
+
+### Keys, names, grouping
+
+- **Never rename existing keys** (action IDs). New keys: PascalCase, short, unique (`Meltagun`, `BulletStorm`, `SupplyFRV`)
+- `name`: 2-3 words for labels. Keep the distinctive word last
+- Add a `# WARBOND / SHIP MODULE` comment section matching existing style
+- Confirm the wiki page exists and the sequence looks real before adding
+
+## Phase 4: Generate and verify
+
+```bash
+source .venv/bin/activate
+python -m update generate-all --skip-pages -v
+python -m update discover -v    # must be 0 new wiki, 0 unmapped SVGs
+python -m update validate       # no errors; extra CLASS/custom icons are fine
+```
+
+Always `--skip-pages`. Default pages path is not the Flatpak install.
+
+Expect only: `config.py`, `stratagems.json`, `locales/en_US.json`, **new** icon PNGs, version files. If existing PNGs rewrite with no visual change, leave them unstaged.
+
+## Phase 5: Version
+
+Bump both:
+
+- `manifest.json` → `version`
+- `main.py` → `plugin_version=`
+
+Same `X.Y.Z` as the branch name.
+
+## Phase 6: Plugin PR
+
+Only after the user asks to commit/push/PR.
+
+- Title: `vX.Y.Z: Add new stratagems from recent warbonds` (or the actual reason)
+- Body: terse bullets, list new keys/names, call out renames that kept their key
+- Remote: `origin` on `jslay88/streamcontroller_helldivers_2`
+- Follow the user git/PR rules (HEREDOC commit, `gh pr create`)
+
+If they name a related issue, put the full URL in the PR body.
+
+## Phase 7: Local Flatpak test
+
+See [local.md](local.md). Summary:
+
+1. Backup `net_jslay_helldivers_2` if it is a real directory
+2. Symlink the git checkout into the Flatpak plugins dir
+3. Set `store.auto-update` to `false` **before** StreamController restarts (auto-update compares SHAs and `rmtree`s the plugin path; that can follow the symlink into this repo)
+4. Restart or launch StreamController
+5. Launch the tester if asked:
+
+```bash
+source .venv/bin/activate
+python test_stratagems.py
+```
+
+## Phase 8: Store PR
+
+Only after the plugin change is on `origin/main` (merge commit SHA).
+
+Store checkout: `/home/jslay/dev/StreamController-Store`
+
+```bash
+git fetch upstream
+git checkout -B update-plugin-helldivers_2-<fullsha> upstream/main
+```
+
+In `Plugins.json`, set the helldivers entry `hash` to the **full** `origin/main` SHA (merge commit, not the feature commit). Schema is `{ "url", "hash" }` (not `commits`).
+
+- Push to `origin` (`jslay88/StreamController-Store`)
+- `gh pr create --repo StreamController/StreamController-Store --base main --head jslay88:<branch>`
+- Title: `update(helldivers_2): update hash for main`
+- Body: new hash, plugin version, plugin PR URL, plus any issue URL they asked to link
+- Check the store PR template boxes if they already tested locally
+
+## Phase 9: Restore local install
+
+See [local.md](local.md). Remove the symlink, move the backup back, set `store.auto-update` to `true`. Tell the user to restart StreamController if it is running.

--- a/.cursor/skills/add-stratagems/SKILL.md
+++ b/.cursor/skills/add-stratagems/SKILL.md
@@ -2,7 +2,7 @@
 name: add-stratagems
 description: >-
   Discover, map, generate, and ship new HELLDIVERS 2 stratagems for the
-  StreamController plugin, including plugin PRs, local Flatpak testing, and
+  StreamController plugin, including plugin PRs, local testing, and
   StreamController-Store hash bumps. Use when the user invokes add-stratagems,
   asks to add new stratagems, run discover, ship a plugin version, open a store
   PR, or restore the local StreamController install.
@@ -11,9 +11,11 @@ disable-model-invocation: true
 
 # Add Helldivers 2 Stratagems
 
-End-to-end workflow for new in-game stratagems. Read [AGENTS.md](../../../AGENTS.md) for label rules. Read [local.md](local.md) before any local StreamController or store-fork step. Use `jslay-writing-style` for commits and PR bodies.
+End-to-end workflow for new in-game stratagems. Read [AGENTS.md](../../../AGENTS.md) for label rules. Read [local.md](local.md) before any local StreamController or store-fork step.
 
 Do **not** commit or push unless the user asks.
+
+Resolve paths at runtime. Never assume a home directory, clone location, GitHub user, or remotes. See [local.md](local.md).
 
 ## Phase selection
 
@@ -27,7 +29,7 @@ Do **not** commit or push unless the user asks.
 
 ## Phase 1: Fresh main
 
-Plugin repo: `/home/jslay/dev/streamcontroller_helldivers_2`
+Work in the plugin repo root (directory that contains `update/config.py` and `manifest.json` with id `net_jslay_helldivers_2`).
 
 ```bash
 git fetch origin
@@ -41,8 +43,7 @@ git checkout -b feat/vX.Y.Z-new-stratagems
 ## Phase 2: Discover
 
 ```bash
-cd /home/jslay/dev/streamcontroller_helldivers_2
-python3 --version   # asdf python is fine
+python3 --version
 [ -d .venv ] || python3 -m venv .venv
 source .venv/bin/activate
 pip install -q -r update/requirements.txt
@@ -92,7 +93,7 @@ python -m update discover -v    # must be 0 new wiki, 0 unmapped SVGs
 python -m update validate       # no errors; extra CLASS/custom icons are fine
 ```
 
-Always `--skip-pages`. Default pages path is not the Flatpak install.
+Always `--skip-pages` unless the user gives an explicit `--pages-dir`. The default pages path is not the StreamController install.
 
 Expect only: `config.py`, `stratagems.json`, `locales/en_US.json`, **new** icon PNGs, version files. If existing PNGs rewrite with no visual change, leave them unstaged.
 
@@ -111,20 +112,21 @@ Only after the user asks to commit/push/PR.
 
 - Title: `vX.Y.Z: Add new stratagems from recent warbonds` (or the actual reason)
 - Body: terse bullets, list new keys/names, call out renames that kept their key
-- Remote: `origin` on `jslay88/streamcontroller_helldivers_2`
-- Follow the user git/PR rules (HEREDOC commit, `gh pr create`)
+- Push to `origin` and open the PR against that remote's default branch
+- Follow the user's git/PR rules (HEREDOC commit, `gh pr create`)
 
 If they name a related issue, put the full URL in the PR body.
 
-## Phase 7: Local Flatpak test
+## Phase 7: Local install test
 
 See [local.md](local.md). Summary:
 
-1. Backup `net_jslay_helldivers_2` if it is a real directory
-2. Symlink the git checkout into the Flatpak plugins dir
-3. Set `store.auto-update` to `false` **before** StreamController restarts (auto-update compares SHAs and `rmtree`s the plugin path; that can follow the symlink into this repo)
-4. Restart or launch StreamController
-5. Launch the tester if asked:
+1. Locate the StreamController data dir and the installed `net_jslay_helldivers_2` plugin
+2. Backup that plugin directory if it is a real directory
+3. Symlink this git checkout over it
+4. Set `store.auto-update` to `false` **before** StreamController restarts (auto-update compares SHAs and `rmtree`s the plugin path; that can follow the symlink into this repo)
+5. Restart or launch StreamController
+6. Launch the tester if asked:
 
 ```bash
 source .venv/bin/activate
@@ -135,17 +137,17 @@ python test_stratagems.py
 
 Only after the plugin change is on `origin/main` (merge commit SHA).
 
-Store checkout: `/home/jslay/dev/StreamController-Store`
+Locate a StreamController-Store checkout (see [local.md](local.md)). Need remotes: `upstream` → `StreamController/StreamController-Store`, `origin` → the user's fork.
 
 ```bash
 git fetch upstream
 git checkout -B update-plugin-helldivers_2-<fullsha> upstream/main
 ```
 
-In `Plugins.json`, set the helldivers entry `hash` to the **full** `origin/main` SHA (merge commit, not the feature commit). Schema is `{ "url", "hash" }` (not `commits`).
+In `Plugins.json`, set the helldivers entry `hash` to the **full** plugin-repo `origin/main` SHA (merge commit, not the feature commit). Schema is `{ "url", "hash" }` (not `commits`).
 
-- Push to `origin` (`jslay88/StreamController-Store`)
-- `gh pr create --repo StreamController/StreamController-Store --base main --head jslay88:<branch>`
+- Push to `origin`
+- `gh pr create --repo StreamController/StreamController-Store --base main --head <fork-owner>:<branch>`
 - Title: `update(helldivers_2): update hash for main`
 - Body: new hash, plugin version, plugin PR URL, plus any issue URL they asked to link
 - Check the store PR template boxes if they already tested locally

--- a/.cursor/skills/add-stratagems/local.md
+++ b/.cursor/skills/add-stratagems/local.md
@@ -1,0 +1,54 @@
+# Local paths (jslay)
+
+## Repos
+
+| Role | Path | Remotes |
+|------|------|---------|
+| Plugin | `/home/jslay/dev/streamcontroller_helldivers_2` | `origin` → `jslay88/streamcontroller_helldivers_2` |
+| Store fork | `/home/jslay/dev/StreamController-Store` | `origin` → `jslay88/StreamController-Store`, `upstream` → `StreamController/StreamController-Store` |
+| StreamController source | `/home/jslay/dev/StreamController` | not used for this workflow |
+
+Live install is the **Flatpak**, not the source checkout.
+
+## Flatpak
+
+```
+~/.var/app/com.core447.StreamController/data/plugins/net_jslay_helldivers_2
+~/.var/app/com.core447.StreamController/data/settings/settings.json
+```
+
+`com.core447.StreamController` has `filesystems=home`, so a symlink into `~/dev/...` works.
+
+`settings.json` key: `store.auto-update` (boolean). This is global (all store assets). There is no per-plugin switch.
+
+## Link for testing
+
+```bash
+PLUGIN_DIR="$HOME/.var/app/com.core447.StreamController/data/plugins"
+SRC="$HOME/dev/streamcontroller_helldivers_2"
+TARGET="$PLUGIN_DIR/net_jslay_helldivers_2"
+BACKUP="$PLUGIN_DIR/net_jslay_helldivers_2.store.bak"
+
+# If TARGET is already a symlink to SRC, skip.
+# If BACKUP exists, stop and ask.
+
+mv "$TARGET" "$BACKUP"
+ln -s "$SRC" "$TARGET"
+```
+
+Then set `store.auto-update` to `false` in `settings.json`. Confirm `manifest.json` through the symlink is the checkout version.
+
+## Restore
+
+```bash
+PLUGIN_DIR="$HOME/.var/app/com.core447.StreamController/data/plugins"
+TARGET="$PLUGIN_DIR/net_jslay_helldivers_2"
+BACKUP="$PLUGIN_DIR/net_jslay_helldivers_2.store.bak"
+
+rm "$TARGET"          # symlink only
+mv "$BACKUP" "$TARGET"
+```
+
+Set `store.auto-update` to `true`. Confirm `TARGET` is a directory, not a symlink, and `manifest.json` is the store version.
+
+If the backup name from an older run was `net_jslay_helldivers_2.store-2.3.1.bak`, use that path instead.

--- a/.cursor/skills/add-stratagems/local.md
+++ b/.cursor/skills/add-stratagems/local.md
@@ -1,33 +1,75 @@
-# Local paths (jslay)
+# Locate local installs
 
-## Repos
+Resolve everything below at runtime. Do not hardcode home directories, clone paths, or GitHub usernames.
 
-| Role | Path | Remotes |
-|------|------|---------|
-| Plugin | `/home/jslay/dev/streamcontroller_helldivers_2` | `origin` → `jslay88/streamcontroller_helldivers_2` |
-| Store fork | `/home/jslay/dev/StreamController-Store` | `origin` → `jslay88/StreamController-Store`, `upstream` → `StreamController/StreamController-Store` |
-| StreamController source | `/home/jslay/dev/StreamController` | not used for this workflow |
+## Plugin repo
 
-Live install is the **Flatpak**, not the source checkout.
+The plugin root is the directory that contains both `update/config.py` and `manifest.json` with `"id": "net_jslay_helldivers_2"`.
 
-## Flatpak
+Prefer the current workspace root. If this skill is running from another workspace, search sibling directories and ask if it is still unclear.
 
-```
-~/.var/app/com.core447.StreamController/data/plugins/net_jslay_helldivers_2
-~/.var/app/com.core447.StreamController/data/settings/settings.json
+```bash
+# from plugin root
+git remote -v
+git rev-parse --show-toplevel
 ```
 
-`com.core447.StreamController` has `filesystems=home`, so a symlink into `~/dev/...` works.
+## Store checkout
+
+Look for a clone of `StreamController/StreamController-Store` or a fork of it:
+
+1. Other workspace roots in this session
+2. Sibling directories of the plugin repo (`../StreamController-Store`, `../streamcontroller-store`, etc.)
+3. `gh repo list --fork` / ask the user
+
+Required remotes once found:
+
+| Remote | Repo |
+|--------|------|
+| `upstream` | `StreamController/StreamController-Store` |
+| `origin` | the user's fork |
+
+If `upstream` is missing, add it. Fork owner for `--head` is the `origin` GitHub owner (`git remote get-url origin`), not a hardcoded username.
+
+## StreamController data dir
+
+Live plugin files come from the **installed app**, not a StreamController source checkout.
+
+Search in order and use the first that contains `plugins/net_jslay_helldivers_2`:
+
+```bash
+PLUGIN_ID="net_jslay_helldivers_2"
+
+# Flatpak (typical on Linux)
+echo "$HOME/.var/app/com.core447.StreamController/data"
+
+# Native / custom --data path
+echo "${XDG_DATA_HOME:-$HOME/.local/share}/StreamController"
+# also check running process args for --data
+```
+
+Confirm:
+
+```
+$DATA/plugins/$PLUGIN_ID/manifest.json
+$DATA/settings/settings.json
+```
+
+If both Flatpak and a native install exist, ask which one they are testing. If the plugin is not installed, say so and skip link/restore.
 
 `settings.json` key: `store.auto-update` (boolean). This is global (all store assets). There is no per-plugin switch.
 
+Flatpak `com.core447.StreamController` usually has `filesystems=home`, so a symlink into a repo under `$HOME` works. If the install is sandboxed without home access, stop and tell the user.
+
 ## Link for testing
 
+`SRC` is the plugin repo root from above (`git rev-parse --show-toplevel`).
+
 ```bash
-PLUGIN_DIR="$HOME/.var/app/com.core447.StreamController/data/plugins"
-SRC="$HOME/dev/streamcontroller_helldivers_2"
-TARGET="$PLUGIN_DIR/net_jslay_helldivers_2"
-BACKUP="$PLUGIN_DIR/net_jslay_helldivers_2.store.bak"
+PLUGIN_ID="net_jslay_helldivers_2"
+PLUGIN_DIR="$DATA/plugins"
+TARGET="$PLUGIN_DIR/$PLUGIN_ID"
+BACKUP="$PLUGIN_DIR/${PLUGIN_ID}.store.bak"
 
 # If TARGET is already a symlink to SRC, skip.
 # If BACKUP exists, stop and ask.
@@ -36,19 +78,18 @@ mv "$TARGET" "$BACKUP"
 ln -s "$SRC" "$TARGET"
 ```
 
-Then set `store.auto-update` to `false` in `settings.json`. Confirm `manifest.json` through the symlink is the checkout version.
+Then set `store.auto-update` to `false` in `$DATA/settings/settings.json`. Confirm `manifest.json` through the symlink is the checkout version.
 
 ## Restore
 
 ```bash
-PLUGIN_DIR="$HOME/.var/app/com.core447.StreamController/data/plugins"
-TARGET="$PLUGIN_DIR/net_jslay_helldivers_2"
-BACKUP="$PLUGIN_DIR/net_jslay_helldivers_2.store.bak"
+TARGET="$PLUGIN_DIR/$PLUGIN_ID"
+BACKUP="$PLUGIN_DIR/${PLUGIN_ID}.store.bak"
 
-rm "$TARGET"          # symlink only
+# If the backup used a versioned suffix (*.store-*.bak), use that path instead.
+
+rm "$TARGET"          # symlink only; do not rm -rf
 mv "$BACKUP" "$TARGET"
 ```
 
 Set `store.auto-update` to `true`. Confirm `TARGET` is a directory, not a symlink, and `manifest.json` is the store version.
-
-If the backup name from an older run was `net_jslay_helldivers_2.store-2.3.1.bak`, use that path instead.


### PR DESCRIPTION
## Summary
- Add a project skill for the new-stratagems workflow (discover, map, generate, version, plugin PR, local Flatpak test, store PR, restore)
- Local Flatpak/store-fork paths live in `local.md`

## Test plan
- [ ] Invoke **add-stratagems** in a new chat and confirm it loads the skill